### PR TITLE
Identify street names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 19.3b0
     hooks:
     -   id: black
-- repo: https://github.com/pre-commit/mirrors-isort
+-   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.20
     hooks:
     - id: isort

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 # unit testing
   - pytest >=4.4  # for unit testing
 # code quality
+  - pre-commit  # for automatic code quality checking
   - black  # for automatic code formatting
   - isort  # for import standardization
   - flake8  # for linting

--- a/privacypanda/__init__.py
+++ b/privacypanda/__init__.py
@@ -1,3 +1,3 @@
-from .addresses import check_addresses
+from .addresses import *
 
 __version__ = "0.1.0dev"

--- a/privacypanda/addresses.py
+++ b/privacypanda/addresses.py
@@ -9,10 +9,21 @@ import pandas as pd
 
 OBJECT_DTYPE = np.dtype("O")
 
-# Regex constants
+# ----- Regex constants ----- #
 LETTER = "[a-zA-Z]"
+
+# UK Postcode
 UK_POSTCODE_PATTERN = re.compile(
     LETTER + LETTER + "\\d{1,2}" + "\\s+" + "\\d" + LETTER + LETTER
+)
+
+# Street names
+STREET_ENDINGS = "[street|road|way|avenue]"
+
+# Simple address is up to a four digit number + street name with 1-10 characters
+# + one of "road", "street", "way", "avenue"
+SIMPLE_ADDRESS_PATTERN = re.compile(
+    "[0-9]{1,4}\\s[a-z]{1,10}\\s" + STREET_ENDINGS, re.I
 )
 
 
@@ -21,15 +32,7 @@ def check_addresses(df: pd.DataFrame) -> List:
     Check a dataframe for columns containing addresses. Returns a list of column
     names which contain at least one address
 
-    "Addresses" currently only concerns UK postcodes, which are of the form:
-    * Two letters
-    * One or two digits
-    * Whitespace
-    * One digit
-    * Two letters
-    E.g.:
-    * AB1 1AB
-    * AB12 1AB
+    "Addresses" currently only concerns UK postcodes and simple street names.
     This implementation does not consider whether the addresses are real.
 
     Parameters
@@ -41,7 +44,6 @@ def check_addresses(df: pd.DataFrame) -> List:
     -------
     List
         The names of columns which contain at least one address
-
     """
     private_cols = []
 
@@ -52,7 +54,9 @@ def check_addresses(df: pd.DataFrame) -> List:
         if row.dtype == OBJECT_DTYPE:
             for item in row:
 
-                if UK_POSTCODE_PATTERN.match(item):
+                if UK_POSTCODE_PATTERN.match(item) or SIMPLE_ADDRESS_PATTERN.match(
+                    item
+                ):
                     private_cols.append(col)
                     break  # 1 failure is enough
 

--- a/privacypanda/addresses.py
+++ b/privacypanda/addresses.py
@@ -7,6 +7,8 @@ from typing import List
 import numpy as np
 import pandas as pd
 
+__all__ = ["check_addresses"]
+
 OBJECT_DTYPE = np.dtype("O")
 
 # ----- Regex constants ----- #

--- a/tests/test_address_identification.py
+++ b/tests/test_address_identification.py
@@ -7,20 +7,10 @@ import pytest
 import privacypanda as pp
 
 
-def test_can_identify_column_containing_simple_UK_postcode():
+@pytest.mark.parametrize("postcode", ["AB1 1AB", "AB12 1AB", "AB1    1AB"])
+def test_can_identify_column_containing_UK_postcode(postcode):
     df = pd.DataFrame(
-        {"privateColumn": ["a", "AB1 1AB", "c"], "nonPrivateColumn": ["a", "b", "c"]}
-    )
-
-    actual_private_columns = pp.check_addresses(df)
-    expected_private_columns = ["privateColumn"]
-
-    assert actual_private_columns == expected_private_columns
-
-
-def test_can_identify_column_containing_simple_UK_postcode_with_extra_digit():
-    df = pd.DataFrame(
-        {"privateColumn": ["a", "AB12 1AB", "c"], "nonPrivateColumn": ["a", "b", "c"]}
+        {"privateColumn": ["a", postcode, "c"], "nonPrivateColumn": ["a", "b", "c"]}
     )
 
     actual_private_columns = pp.check_addresses(df)
@@ -36,16 +26,5 @@ def test_address_check_returns_empty_list_if_no_addresses_found():
 
     actual_private_columns = pp.check_addresses(df)
     expected_private_columns = []
-
-    assert actual_private_columns == expected_private_columns
-
-
-def test_identifies_UK_postcode_with_tab_separated_sections():
-    df = pd.DataFrame(
-        {"privateColumn": ["a", "AB12   1AB", "c"], "nonPrivateColumn": ["a", "b", "c"]}
-    )
-
-    actual_private_columns = pp.check_addresses(df)
-    expected_private_columns = ["privateColumn"]
 
     assert actual_private_columns == expected_private_columns

--- a/tests/test_address_identification.py
+++ b/tests/test_address_identification.py
@@ -19,6 +19,29 @@ def test_can_identify_column_containing_UK_postcode(postcode):
     assert actual_private_columns == expected_private_columns
 
 
+@pytest.mark.parametrize(
+    "address",
+    [
+        "10 Downing Street",
+        "10 downing street",
+        "1 the Road",
+        "01 The Road",
+        "1234 The Road",
+        "55 Maple Avenue",
+        "4 Python Way",
+    ],
+)
+def test_can_identify_column_containing_simple_street_names(address):
+    df = pd.DataFrame(
+        {"privateColumn": ["a", address, "c"], "nonPrivateColumn": ["a", "b", "c"]}
+    )
+
+    actual_private_columns = pp.check_addresses(df)
+    expected_private_columns = ["privateColumn"]
+
+    assert actual_private_columns == expected_private_columns
+
+
 def test_address_check_returns_empty_list_if_no_addresses_found():
     df = pd.DataFrame(
         {"nonPrivateColumn1": ["a", "b", "c"], "nonPrivateColumn2": ["a", "b", "c"]}


### PR DESCRIPTION
**This PR**:
Extends checks for addresses to include a simple street name:
* A house number of up to four digits (characters are not included in this PR, e.g. 221B)
* A street name of up to 10 characters
* A suffix, one of "road", "street", "avenue", "way"

**To test**:
Unit tests have been included

Fixes partially #3 