### PR TITLE
Identify uk phonenumbers

### DIFF
--- a/privacypanda/__init__.py
+++ b/privacypanda/__init__.py
@@ -1,6 +1,7 @@
 from .addresses import *
 from .anonymize import *
 from .email import *
+from .phonenumbers import *
 from .report import *
 
 __version__ = "0.1.0dev"

--- a/privacypanda/addresses.py
+++ b/privacypanda/addresses.py
@@ -20,7 +20,7 @@ UK_POSTCODE_PATTERN = re.compile(
 )
 
 # Street names
-STREET_ENDINGS = "[street|road|way|avenue]"
+STREET_ENDINGS = r"(street|road|way|avenue)"
 
 # Simple address is up to a four digit number + street name with 1-10 characters
 # + one of "road", "street", "way", "avenue"

--- a/privacypanda/anonymize.py
+++ b/privacypanda/anonymize.py
@@ -6,6 +6,7 @@ from numpy import unique as np_unique
 
 from .addresses import check_addresses
 from .email import check_emails
+from .phonenumbers import check_phonenumbers
 
 
 def anonymize(df: pd.DataFrame) -> pd.DataFrame:
@@ -28,7 +29,7 @@ def anonymize(df: pd.DataFrame) -> pd.DataFrame:
     """
     private_cols = []
 
-    checks = [check_addresses, check_emails]
+    checks = [check_addresses, check_emails, check_phonenumbers]
     for check in checks:
         new_private_cols = check(df)
         private_cols += new_private_cols

--- a/privacypanda/email.py
+++ b/privacypanda/email.py
@@ -14,7 +14,7 @@ OBJECT_DTYPE = np_dtype("O")
 # Whitelisted email suffix.
 # TODO extend this
 WHITELIST_EMAIL_SUFFIXES = [".co.uk", ".com", ".org", ".edu"]
-EMAIL_SUFFIX_REGEX = "[" + r"|".join(WHITELIST_EMAIL_SUFFIXES) + "]"
+EMAIL_SUFFIX_REGEX = "(" + r"|".join(WHITELIST_EMAIL_SUFFIXES) + ")"
 
 # Simple email pattern
 SIMPLE_EMAIL_PATTERN = re.compile(".*@.*" + EMAIL_SUFFIX_REGEX, re.I)

--- a/privacypanda/phonenumbers.py
+++ b/privacypanda/phonenumbers.py
@@ -1,0 +1,53 @@
+"""
+Code for identifying phonenumbers
+"""
+import re
+from typing import List
+
+import pandas as pd
+from numpy import dtype as np_dtype
+
+__all__ = ["check_phonenumbers"]
+
+OBJECT_DTYPE = np_dtype("O")
+
+# REGEX
+NUMBER_PREFIX = r"(\+44|0)7"
+
+# A simple UK phone number is +447 or 07, followed by 9 digits
+SIMPLE_UK_MOBILE = re.compile(NUMBER_PREFIX + "[0-9]{9}")
+
+
+def check_phonenumbers(df: pd.DataFrame) -> List:
+    """
+    Check a dataframe for columns containing phonenumbers. Returns a list of column
+    names which contain at least one address
+
+    "Addresses" currently only concerns UK mobile numbers. These begin with
+    +44/0 7, then 9 digits.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The dataframe to check
+
+    Returns
+    -------
+    List
+        The names of columns which contain at least one phonenumber
+    """
+    private_cols = []
+
+    for col in df:
+        row = df[col]
+
+        # Only check column if it may contain strings
+        if row.dtype == OBJECT_DTYPE:
+            for item in row:
+                item = str(item)  # convert incase column has mixed data types
+
+                if SIMPLE_UK_MOBILE.fullmatch(item):
+                    private_cols.append(col)
+                    break  # 1 failure is enough
+
+    return private_cols

--- a/privacypanda/report.py
+++ b/privacypanda/report.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, List, Union
 
 from .addresses import check_addresses
 from .email import check_emails
+from .phonenumbers import check_phonenumbers
 
 if TYPE_CHECKING:
     import pandas
@@ -58,7 +59,11 @@ class Report:
 def report_privacy(df: "pandas.DataFrame") -> Report:
     report = Report()
 
-    checks = {"address": check_addresses, "email": check_emails}
+    checks = {
+        "address": check_addresses,
+        "email": check_emails,
+        "phone number": check_phonenumbers,
+    }
 
     for breach, check in checks.items():
         columns = check(df)

--- a/tests/test_address_identification.py
+++ b/tests/test_address_identification.py
@@ -42,6 +42,28 @@ def test_can_identify_column_containing_simple_street_names(address):
     assert actual_private_columns == expected_private_columns
 
 
+@pytest.mark.parametrize(
+    "address",
+    [
+        "10 Downing St",
+        "10 downing st",
+        "1 the rd",
+        "01 The Place",
+        "55 Maple Ave",
+        "4 Python Wy",
+    ],
+)
+def test_does_not_identify_non_whitelisted_street_types_as_addresses(address):
+    df = pd.DataFrame(
+        {"privateColumn": ["a", address, "c"], "nonPrivateColumn": ["a", "b", "c"]}
+    )
+
+    actual_private_columns = pp.check_addresses(df)
+    expected_private_columns = []
+
+    assert actual_private_columns == expected_private_columns
+
+
 def test_address_check_returns_empty_list_if_no_addresses_found():
     df = pd.DataFrame(
         {"nonPrivateColumn1": ["a", "b", "c"], "nonPrivateColumn2": ["a", "b", "c"]}

--- a/tests/test_anonymization.py
+++ b/tests/test_anonymization.py
@@ -39,6 +39,25 @@ def test_removes_columns_containing_addresses(address):
     pd.testing.assert_frame_equal(actual_df, expected_df)
 
 
+@pytest.mark.parametrize("number", ["07123456789", "+447345345345"])
+def test_removes_columns_containing_phonenumbers(number):
+    df = pd.DataFrame(
+        {
+            "privateData": ["a", "b", "c", number],
+            "nonPrivateData": ["a", "b", "c", "d"],
+            "nonPrivataData2": [1, 2, 3, 4],
+        }
+    )
+
+    expected_df = pd.DataFrame(
+        {"nonPrivateData": ["a", "b", "c", "d"], "nonPrivataData2": [1, 2, 3, 4]}
+    )
+
+    actual_df = pp.anonymize(df)
+
+    pd.testing.assert_frame_equal(actual_df, expected_df)
+
+
 @pytest.mark.parametrize(
     "email",
     [
@@ -69,8 +88,8 @@ def test_removes_columns_containing_emails(email):
 def test_returns_empty_dataframe_if_all_columns_contain_private_information():
     df = pd.DataFrame(
         {
-            "nonPrivateData": ["a", "AB1 1AB", "c", "d"],
-            "PrivataData2": [1, 2, 3, "AB1 1AB"],
+            "PrivateData": ["a", "AB1 1AB", "c", "d"],
+            "PrivataData2": [1, 2, 3, "07123456789"],
         }
     )
 

--- a/tests/test_email_identification.py
+++ b/tests/test_email_identification.py
@@ -33,6 +33,20 @@ def test_address_check_returns_empty_list_if_no_emails_found():
     assert actual_private_columns == expected_private_columns
 
 
+@pytest.mark.parametrize(
+    "email", ["some@thing.net", "a@test.test", "new.zealand@place.nz"]
+)
+def test_does_not_identify_non_whitelisted_suffixes_as_emails(email):
+    df = pd.DataFrame(
+        {"privateColumn": ["a", email, "c"], "nonPrivateColumn": ["a", "b", "c"]}
+    )
+
+    actual_private_columns = pp.check_addresses(df)
+    expected_private_columns = []
+
+    assert actual_private_columns == expected_private_columns
+
+
 def test_check_emails_can_handle_mixed_dtype_columns():
     df = pd.DataFrame(
         {

--- a/tests/test_phonenumber_identification.py
+++ b/tests/test_phonenumber_identification.py
@@ -1,0 +1,32 @@
+"""
+Test functions for identifying phonenumbers in dataframes
+"""
+import pandas as pd
+import pytest
+
+import privacypanda as pp
+
+
+@pytest.mark.parametrize("number", ["+447123456789", "07123456789", "07999999999"])
+def test_can_identify_column_containing_correct_phonenumbers(number):
+    df = pd.DataFrame(
+        {"privateColumn": ["a", number, "c"], "nonPrivateColumn": ["a", "b", "c"]}
+    )
+
+    actual_private_columns = pp.check_phonenumbers(df)
+    expected_private_columns = ["privateColumn"]
+
+    assert actual_private_columns == expected_private_columns
+
+
+@pytest.mark.parametrize("number", ["+4412345678", "071234567891011", "999"])
+def test_number_must_have_nine_digits(number):
+    # 9 digits AFTER "07"
+    df = pd.DataFrame(
+        {"privateColumn": ["a", number, "c"], "nonPrivateColumn": ["a", "b", "c"]}
+    )
+
+    actual_private_columns = pp.check_phonenumbers(df)
+    expected_private_columns = []
+
+    assert actual_private_columns == expected_private_columns

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -29,6 +29,28 @@ def test_can_report_addresses():
     assert actual_string == expected_string
 
 
+def test_can_report_phonenumbers():
+    df = pd.DataFrame(
+        {
+            "col1": ["a", "b", "07987654321"],
+            "col2": [1, 2, 3],
+            "col3": ["+447123123123", "b", "c"],
+        }
+    )
+
+    # Check correct breaches have been logged
+    report = pp.report_privacy(df)
+    expected_breaches = {"col1": ["phone number"], "col3": ["phone number"]}
+
+    assert report._breaches == expected_breaches
+
+    # Check string report
+    actual_string = str(report)
+    expected_string = "col1: ['phone number']\ncol3: ['phone number']\n"
+
+    assert actual_string == expected_string
+
+
 def test_can_report_emails():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
**This pr**:
* Add identification of UK mobile numbers
* Fixes a bug in email and address search caused by using `[ ]` to define a set of optional suffixes instead of `( )`

**to test**:
Unit tests added